### PR TITLE
Add π-shifted ferromagnetic Josephson junctions (π-junction)

### DIFF
--- a/include/JoSIM/Components.hpp
+++ b/include/JoSIM/Components.hpp
@@ -39,6 +39,7 @@ namespace JoSIM {
       CCVS>> devices;
     std::vector<CurrentSource> currentsources;
     std::vector<int> junctionIndices,
+      pjunctionIndices,
       resistorIndices,
       inductorIndices,
       capacitorIndices,

--- a/include/JoSIM/Simulation.hpp
+++ b/include/JoSIM/Simulation.hpp
@@ -53,6 +53,7 @@ namespace JoSIM {
     void handle_inductors(Matrix& mObj, double factor = 1);
     void handle_capacitors(Matrix& mObj);
     void handle_jj(Matrix& mObj, int& i, double& step, double factor = 1);
+    void handle_pijj(Matrix& mObj, int& i, double& step, double factor = 1);
     void handle_vs(
       Matrix& mObj, const int& i, double& step, double factor = 1);
     void handle_ps(

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -129,6 +129,14 @@ void Matrix::create_matrix(Input& iObj) {
       // Store this JJ's component list index for reference    
       components.junctionIndices.emplace_back(components.devices.size() - 1);
       break;
+      // pi-Josephson junction (PJJ)
+    case 'Q':
+      // Create a JJ and add it to the component list
+      components.devices.emplace_back(
+        JJ(i, nodeConfig.at(cc), nm, lm, nc, iObj, spread, branchIndex));
+      // Store this JJ's component list index for reference    
+      components.pjunctionIndices.emplace_back(components.devices.size() - 1);
+      break;
       // Resistors
     case 'R':
       // Create a resistor and add it to the component list


### PR DESCRIPTION
Sorry for the pull request again.
I've modified the code to be more concise.

I would like JoSIM to recognize π-shifted ferromagnetic Josephson junctions (π-junction), so I will make a pull request.

This is π-junction RCSJ model
![image](https://user-images.githubusercontent.com/75787495/142560585-a952cdd6-2b3a-492b-98ee-fec1ed20a287.png)

This is the test data.  [testdata](https://raw.githubusercontent.com/tanetakumi/hfq-optimizer/main/test/test.inp)
The Charactor for recognizing the π-junction is tentatively set to ”Q”.
This circuits is based on the 0-π SQUID, which is composed of conventional Josephson junctions (0-junction) and a π-junction.
From this test netlist file, we can get the following results.

Y axis is ”Phase” 
![image](https://user-images.githubusercontent.com/75787495/142571025-37efdd94-78b4-47f4-a73e-a7e30f6983f9.png)