### PR TITLE
Fix errors in standard input

### DIFF
--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -15,9 +15,12 @@ using namespace JoSIM;
 
 std::vector<tokens_t> Input::read_input(
   LineInput& input, string_o fileName) {
-  if (std::filesystem::path(fileName.value()).has_parent_path()) {
-    fileParentPath =
-      std::filesystem::path(fileName.value()).parent_path().string();
+  //When the standard input is selected, "fileName" will be in the nullopt state.
+  if(fileName != std::nullopt){
+    if (std::filesystem::path(fileName.value()).has_parent_path()) {
+      fileParentPath =
+        std::filesystem::path(fileName.value()).parent_path().string();
+    }
   }
   // Variable to store the read line
   std::string line;
@@ -85,6 +88,9 @@ std::vector<tokens_t> Input::read_input(
           output_files.emplace_back(OutputFile(path.string()));
         }
         fileLines.emplace_back(tokens);
+        // If the line contains a "FINISH" statement
+      } else if (tokens.at(0) == ".FINISH" || tokens.at(0) == "FINISH") {
+        break;
         // If the line does not contain an "INCLUDE" or "FILE" statement
       } else {
         // Transform the entire line to upper case

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -88,10 +88,10 @@ std::vector<tokens_t> Input::read_input(
           output_files.emplace_back(OutputFile(path.string()));
         }
         fileLines.emplace_back(tokens);
-        // If the line contains a "FINISH" statement
-      } else if (tokens.at(0) == ".FINISH" || tokens.at(0) == "FINISH") {
+        // If the line contains a "END" statement
+      } else if (tokens.at(0) == ".END" || tokens.at(0) == "END") {
         break;
-        // If the line does not contain an "INCLUDE" or "FILE" statement
+        // If the line does not contain an "INCLUDE", "FILE" or "END" statement
       } else {
         // Transform the entire line to upper case
         std::transform(tokens.begin() + 1, tokens.end(), tokens.begin() + 1,


### PR DESCRIPTION
When we select Input (-i):, i.e. standard input, the function Input::read_input tries to access fileName.value() even though fileName is nullopt, resulting in bad_optional_access.

I have fixed this.

Also, since it was not specified how to end the standard input, I used ".finish" to terminate.