### PR TITLE
missing headers for linux build

### DIFF
--- a/src/Netlist.cpp
+++ b/src/Netlist.cpp
@@ -3,6 +3,7 @@
 
 #include "JoSIM/Netlist.hpp"
 
+#include <cstring> // for strcmp
 #include <thread>
 
 #include "JoSIM/AnalysisType.hpp"

--- a/src/TransmissionLine.cpp
+++ b/src/TransmissionLine.cpp
@@ -4,6 +4,7 @@
 #include "JoSIM/TransmissionLine.hpp"
 
 #include <algorithm>
+#include <cstring> // for memcmp
 #include <functional>
 #include <iostream>
 #include <locale>


### PR DESCRIPTION
there appears to be missing headers for compiling with gcc or clang
msvc seems to implicitly include some C functions into the global namespace, while the others require `<cstring>` to be included explicitly