### PR TITLE
Added sanity check feature for high-level design simulation of superconductor flux-quantum circuits

### DIFF
--- a/include/JoSIM/BasicComponent.hpp
+++ b/include/JoSIM/BasicComponent.hpp
@@ -40,9 +40,11 @@ class BasicComponent {
   NetlistInfo netlistInfo;
   IndexInfo indexInfo;
   MatrixInfo matrixInfo;
+  tokens_t nodes;
 
   void set_node_indices(const tokens_t& t, const nodemap& nm,
                         nodeconnections& nc) {
+    nodes = t;
     switch (indexInfo.nodeConfig_) {
       case NodeConfig::POSGND:
         indexInfo.posIndex_ = nm.at(t.at(0));

--- a/include/JoSIM/CliOptions.hpp
+++ b/include/JoSIM/CliOptions.hpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <optional>
 #include <string>
+#include <unordered_set>
 
 #include "JoSIM/AnalysisType.hpp"
 #include "JoSIM/FileOutputType.hpp"
@@ -27,7 +28,8 @@ struct CliOptions {
   int64_t verbose = 0;
   bool minimal = false;
   bool parallel = false;
-  bool sanity_check = false;
+  bool sanityCheck = false;
+  std::unordered_set<std::string> sanityCheckSubckts;
 
   // helper functions
   static CliOptions parse(int64_t argc, const char** argv);

--- a/include/JoSIM/CliOptions.hpp
+++ b/include/JoSIM/CliOptions.hpp
@@ -27,6 +27,7 @@ struct CliOptions {
   int64_t verbose = 0;
   bool minimal = false;
   bool parallel = false;
+  bool sanity_check = false;
 
   // helper functions
   static CliOptions parse(int64_t argc, const char** argv);

--- a/include/JoSIM/Input.hpp
+++ b/include/JoSIM/Input.hpp
@@ -43,6 +43,8 @@ class Input {
     argVerb = cli_options.verbose;
     argMin = cli_options.minimal;
     cli_output_file = cli_options.output_file;
+    netlist.sanityCheck = cli_options.sanityCheck;
+    netlist.sanityCheckSubckts = cli_options.sanityCheckSubckts;
   }
 
   std::vector<tokens_t> read_input(LineInput& input,

--- a/include/JoSIM/Matrix.hpp
+++ b/include/JoSIM/Matrix.hpp
@@ -49,7 +49,6 @@ class Matrix {
   void create_nz();
   void create_ci();
   void create_rp();
-  void update_maindesign_node_counts(Netlist& netlist);
 };
 }  // namespace JoSIM
 #endif

--- a/include/JoSIM/Matrix.hpp
+++ b/include/JoSIM/Matrix.hpp
@@ -49,6 +49,7 @@ class Matrix {
   void create_nz();
   void create_ci();
   void create_rp();
+  void update_maindesign_node_counts(Netlist& netlist);
 };
 }  // namespace JoSIM
 #endif

--- a/include/JoSIM/Netlist.hpp
+++ b/include/JoSIM/Netlist.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "JoSIM/Model.hpp"
@@ -60,6 +61,10 @@ class Netlist {
   std::unordered_map<std::string, Subcircuit> subcircuits;
   std::unordered_map<std::string, int64_t> subcktLookup;
   std::vector<tokens_t> maindesign;
+  bool sanityCheck;
+  std::unordered_set<std::string> sanityCheckSubckts;
+  std::unordered_map<std::string, std::unordered_map<std::string, int32_t>>
+      subcktNodeCounts;
   std::unordered_map<std::string, int32_t> mainNodeCounts;
   tokens_t subckts;
   std::vector<std::pair<tokens_t, string_o>> expNetlist;
@@ -74,7 +79,10 @@ class Netlist {
   void expand_subcircuits();
   void expand_maindesign();
   void increment_maindesign_node_count(std::string node);
+  void increment_subcircuit_node_count(std::string subcktName, std::string node);
   void sanity_check_maindesign();
+  void sanity_check_subcircuits();
+  void sanity_check();
 };
 
 }  // namespace JoSIM

--- a/include/JoSIM/Netlist.hpp
+++ b/include/JoSIM/Netlist.hpp
@@ -40,6 +40,7 @@ class Subcircuit {
         };
 };
 
+class Components;
 class Input;
 
 class Netlist {
@@ -54,6 +55,14 @@ class Netlist {
                  const std::string& label);
   void insert_parameter(tokens_t& t, s_map& params);
 
+  std::unordered_map<std::string, std::unordered_map<std::string, int32_t>>
+      subcktNodeCounts;
+  std::unordered_map<std::string, int32_t> mainNodeCounts;
+  void increment_maindesign_node_count(std::string node);
+  void increment_subcircuit_node_count(std::string subcktName, std::string node);
+  void sanity_check_maindesign();
+  void sanity_check_subcircuits();
+
  public:
   std::unordered_map<std::pair<std::string, string_o>, tokens_t, pair_hash>
       models;
@@ -63,9 +72,6 @@ class Netlist {
   std::vector<tokens_t> maindesign;
   bool sanityCheck;
   std::unordered_set<std::string> sanityCheckSubckts;
-  std::unordered_map<std::string, std::unordered_map<std::string, int32_t>>
-      subcktNodeCounts;
-  std::unordered_map<std::string, int32_t> mainNodeCounts;
   tokens_t subckts;
   std::vector<std::pair<tokens_t, string_o>> expNetlist;
   int64_t jjCount, compCount, subcktCounter, nestedSubcktCount, subcktTotal = 0;
@@ -78,11 +84,7 @@ class Netlist {
         containsSubckt(false){};
   void expand_subcircuits();
   void expand_maindesign();
-  void increment_maindesign_node_count(std::string node);
-  void increment_subcircuit_node_count(std::string subcktName, std::string node);
-  void sanity_check_maindesign();
-  void sanity_check_subcircuits();
-  void sanity_check();
+  void sanity_check(Components components);
 };
 
 }  // namespace JoSIM

--- a/include/JoSIM/Netlist.hpp
+++ b/include/JoSIM/Netlist.hpp
@@ -60,6 +60,7 @@ class Netlist {
   std::unordered_map<std::string, Subcircuit> subcircuits;
   std::unordered_map<std::string, int64_t> subcktLookup;
   std::vector<tokens_t> maindesign;
+  std::unordered_map<std::string, int32_t> mainNodeCounts;
   tokens_t subckts;
   std::vector<std::pair<tokens_t, string_o>> expNetlist;
   int64_t jjCount, compCount, subcktCounter, nestedSubcktCount, subcktTotal = 0;
@@ -72,6 +73,8 @@ class Netlist {
         containsSubckt(false){};
   void expand_subcircuits();
   void expand_maindesign();
+  void increment_maindesign_node_count(std::string node);
+  void sanity_check_maindesign();
 };
 
 }  // namespace JoSIM

--- a/src/CliOptions.cpp
+++ b/src/CliOptions.cpp
@@ -150,6 +150,11 @@ CliOptions CliOptions::parse(int64_t argc, const char** argv) {
           std::cout << "Parallelization is DISABLED" << std::endl;
 #endif
           break;
+          // Sanity check input circuit netlist
+        case 's':
+          std::cout << "Sanity check ENABLED" << std::endl;
+          out.sanity_check = true;
+          break;
           // Enable verbose mode
         case 'V':
           try {
@@ -280,6 +285,23 @@ void CliOptions::display_help() {
   std::cout
       << std::setw(16) << std::left << "  " << std::setw(3) << std::left << "|"
       << "Threshold applies, overhead on small circuits negates performance."
+      << std::endl;
+  std::cout << std::setw(16) << std::left << "  " << std::setw(3) << std::left
+            << "|" << std::endl;
+  // Sanity check switch
+  // ---------------------------------------------------------------------------
+  std::cout << std::setw(16) << std::left << "-s" << std::setw(3) << std::left
+            << "|"
+            << "(EXPERIMENTAL) Sanity check input circuit netlist."
+            << std::endl;
+  std::cout << std::setw(16) << std::left << "--sanitycheck" << std::setw(3)
+            << std::left << "|"
+            << "Checks that every superconducting circuit cell node "
+            << "connects to exactly one other node." << std::endl;
+  std::cout
+      << std::setw(16) << std::left << "  " << std::setw(3) << std::left << "|"
+      << "Assumes the circuit uses superconducting circuit cells and "
+      << "the main design specifies high-level connections of those cells."
       << std::endl;
   std::cout << std::setw(16) << std::left << "  " << std::setw(3) << std::left
             << "|" << std::endl;

--- a/src/CliOptions.cpp
+++ b/src/CliOptions.cpp
@@ -152,8 +152,12 @@ CliOptions CliOptions::parse(int64_t argc, const char** argv) {
           break;
           // Sanity check input circuit netlist
         case 's':
-          std::cout << "Sanity check ENABLED" << std::endl;
-          out.sanity_check = true;
+          out.sanityCheck = true;
+          if (i.second) {
+            std::transform(i.second.value().begin(), i.second.value().end(),
+                           i.second.value().begin(), toupper);
+            out.sanityCheckSubckts.insert(i.second.value());
+          }
           break;
           // Enable verbose mode
         case 'V':
@@ -292,16 +296,17 @@ void CliOptions::display_help() {
   // ---------------------------------------------------------------------------
   std::cout << std::setw(16) << std::left << "-s" << std::setw(3) << std::left
             << "|"
-            << "(EXPERIMENTAL) Sanity check input circuit netlist."
+            << "(EXPERIMENTAL) Sanity check circuit netlist (main design). "
+            << "Subcircuits can also be checked if specified."
             << std::endl;
   std::cout << std::setw(16) << std::left << "--sanitycheck" << std::setw(3)
             << std::left << "|"
-            << "Checks that every superconducting circuit cell node "
-            << "connects to exactly one other node." << std::endl;
+            << "Multiple subcircuits can be specified by providing CLI option "
+            << "multiple times. (e.g. -s SUBCKT1 -s SUBCKT2)" << std::endl;
   std::cout
       << std::setw(16) << std::left << "  " << std::setw(3) << std::left << "|"
-      << "Assumes the circuit uses superconducting circuit cells and "
-      << "the main design specifies high-level connections of those cells."
+      << "Checks every superconductor circuit cell node connects to exactly "
+      << "one other node, assuming the design denotes high-level connections."
       << std::endl;
   std::cout << std::setw(16) << std::left << "  " << std::setw(3) << std::left
             << "|" << std::endl;

--- a/src/CurrentSource.cpp
+++ b/src/CurrentSource.cpp
@@ -37,6 +37,7 @@ CurrentSource::CurrentSource(const std::pair<tokens_t, string_o>& s,
 }
 
 void CurrentSource::set_node_indices(const tokens_t& t, const nodemap& nm) {
+  nodes = t;
   switch (indexInfo.nodeConfig_) {
     case NodeConfig::POSGND:
       indexInfo.posIndex_ = nm.at(t.at(0));

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -450,31 +450,3 @@ void Matrix::create_rp() {
     }
   }
 }
-
-void Matrix::update_maindesign_node_counts(Netlist& netlist) {
-  for (auto device: components.devices) {
-    // If device belongs to a subcircuit
-    if (std::visit([](const auto device){
-          return device.netlistInfo.label_.find("|") != std::string::npos;
-        }, device)
-    ) {
-      continue;
-    }
-    // Only consider nodes in maindesign (top)
-    auto nodes = std::visit(
-        [](const auto device){return device.nodes;}, device);
-    for (auto node: nodes) {
-      netlist.increment_maindesign_node_count(node);
-    }
-  }
-  for (auto source: components.currentsources) {
-    // If device belongs to a subcircuit
-    if (source.netlistInfo.label_.find("|") != std::string::npos) {
-      continue;
-    }
-    // Only consider nodes in maindesign (top)
-    for (auto node: source.nodes) {
-      netlist.increment_maindesign_node_count(node);
-    }
-  }
-}

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -450,3 +450,31 @@ void Matrix::create_rp() {
     }
   }
 }
+
+void Matrix::update_maindesign_node_counts(Netlist& netlist) {
+  for (auto device: components.devices) {
+    // If device belongs to a subcircuit
+    if (std::visit([](const auto device){
+          return device.netlistInfo.label_.find("|") != std::string::npos;
+        }, device)
+    ) {
+      continue;
+    }
+    // Only consider nodes in maindesign (top)
+    auto nodes = std::visit(
+        [](const auto device){return device.nodes;}, device);
+    for (auto node: nodes) {
+      netlist.increment_maindesign_node_count(node);
+    }
+  }
+  for (auto source: components.currentsources) {
+    // If device belongs to a subcircuit
+    if (source.netlistInfo.label_.find("|") != std::string::npos) {
+      continue;
+    }
+    // Only consider nodes in maindesign (top)
+    for (auto node: source.nodes) {
+      netlist.increment_maindesign_node_count(node);
+    }
+  }
+}

--- a/src/Netlist.cpp
+++ b/src/Netlist.cpp
@@ -268,16 +268,16 @@ void Netlist::sanity_check_maindesign() {
   for (auto kv: mainNodeCounts) {
     if (kv.second < 2) {
       is_clean = false;
-      std::cout << "Node '" << kv.first
+      std::cout << "- Node '" << kv.first
         << "' looks either undefined or unused." << std::endl;
     } else if (kv.second > 2) {
       is_clean = false;
-      std::cout << "Node '" << kv.first
+      std::cout << "- Node '" << kv.first
         << "' looks overused (" << kv.second << ")." << std::endl;
     }
   }
   if (is_clean) {
-    std::cout << "Everything looks fine." << std::endl;
+    std::cout << "Everything looks fine!" << std::endl;
   }
   std::cout << std::endl;
 }

--- a/src/Netlist.cpp
+++ b/src/Netlist.cpp
@@ -231,6 +231,7 @@ void Netlist::expand_maindesign() {
       s_map params;
       id_io_subc_label(maindesign.at(i), io, params, subcktName, label,
                        subcircuits);
+      for (auto node: io) increment_maindesign_node_count(node);
       // Copy of subcircuit for this instance
       Subcircuit subc = subcircuits.at(subcktName);
       // Expand the appropriate IO nodes of the subcircuit for this instance
@@ -250,4 +251,33 @@ void Netlist::expand_maindesign() {
   }
   subcktTotal = subcircuits.size();
   subcircuits.clear();
+}
+
+void Netlist::increment_maindesign_node_count(std::string node) {
+  if (node == "0" or node == "GND") return;
+  if (mainNodeCounts.count(node) == 0) {
+    mainNodeCounts[node] = 1;
+  } else {
+    mainNodeCounts.at(node)++;
+  }
+}
+
+void Netlist::sanity_check_maindesign() {
+  std::cout << "Sanity check results of main design:" << std::endl;
+  bool is_clean = true;
+  for (auto kv: mainNodeCounts) {
+    if (kv.second < 2) {
+      is_clean = false;
+      std::cout << "Node '" << kv.first
+        << "' looks either undefined or unused." << std::endl;
+    } else if (kv.second > 2) {
+      is_clean = false;
+      std::cout << "Node '" << kv.first
+        << "' looks overused (" << kv.second << ")." << std::endl;
+    }
+  }
+  if (is_clean) {
+    std::cout << "Everything looks fine." << std::endl;
+  }
+  std::cout << std::endl;
 }

--- a/src/Netlist.cpp
+++ b/src/Netlist.cpp
@@ -162,7 +162,7 @@ void Netlist::expand_subcircuits() {
     }
     // Loop through subcircuits
     for (const auto& i : subcircuits) {
-      if (sanityCheck and sanityCheckSubckts.count(i.first) != 0) {
+      if (sanityCheck && sanityCheckSubckts.count(i.first) != 0) {
         for (auto node: i.second.io) {
           increment_subcircuit_node_count(i.first, node);
         }
@@ -179,7 +179,7 @@ void Netlist::expand_subcircuits() {
           s_map params;
           id_io_subc_label(subcCurrentLine, io, params, subcktName, label,
                            subcircuits);
-          if (sanityCheck and sanityCheckSubckts.count(i.first) != 0) {
+          if (sanityCheck && sanityCheckSubckts.count(i.first) != 0) {
             for (auto node: io) increment_subcircuit_node_count(i.first, node);
           }
           // Create a copy of the subircuit for this instance
@@ -265,7 +265,7 @@ void Netlist::expand_maindesign() {
 }
 
 void Netlist::increment_maindesign_node_count(std::string node) {
-  if (node == "0" or node == "GND") return;
+  if (node == "0" || node == "GND") return;
   if (mainNodeCounts.count(node) == 0) {
     mainNodeCounts[node] = 1;
   } else {
@@ -274,7 +274,7 @@ void Netlist::increment_maindesign_node_count(std::string node) {
 }
 
 void Netlist::increment_subcircuit_node_count(std::string subcktName, std::string node) {
-  if (node == "0" or node == "GND") return;
+  if (node == "0" || node == "GND") return;
   if (subcktNodeCounts.count(subcktName) == 0) {
     subcktNodeCounts[subcktName];
   }
@@ -329,7 +329,7 @@ void Netlist::sanity_check_subcircuits() {
 }
 
 void Netlist::sanity_check(Components components) {
-  if (not sanityCheck) return;
+  if (!sanityCheck) return;
 
   // Update node counts in main design
   for (auto device: components.devices) {

--- a/src/TransmissionLine.cpp
+++ b/src/TransmissionLine.cpp
@@ -132,6 +132,7 @@ TransmissionLine::TransmissionLine(
 void TransmissionLine::set_secondary_node_indices(const tokens_t& t,
                                                   const nodemap& nm,
                                                   nodeconnections& nc) {
+  nodes.insert(nodes.end(), t.begin(), t.end());
   // Transmission lines have 4 nodes, this sets the 2nd pair of the 4
   switch (nodeConfig2_) {
     case NodeConfig::POSGND:

--- a/src/josim.cpp
+++ b/src/josim.cpp
@@ -50,10 +50,7 @@ int main(int argc, const char** argv) {
     // Create the matrix in csr format
     mObj.create_matrix(iObj);
     // Do sanity check
-    if (cli_options.sanityCheck) {
-      mObj.update_maindesign_node_counts(iObj.netlist);
-      iObj.netlist.sanity_check();
-    }
+    iObj.netlist.sanity_check(mObj.components);
     // Do verbosity
     Verbose::handle_verbosity(iObj.argVerb, iObj, mObj);
     //  Find the relevant traces to store

--- a/src/josim.cpp
+++ b/src/josim.cpp
@@ -49,6 +49,11 @@ int main(int argc, const char** argv) {
     Matrix mObj;
     // Create the matrix in csr format
     mObj.create_matrix(iObj);
+    // Do sanity check
+    if (cli_options.sanity_check) {
+      mObj.update_maindesign_node_counts(iObj.netlist);
+      iObj.netlist.sanity_check_maindesign();
+    }
     // Do verbosity
     Verbose::handle_verbosity(iObj.argVerb, iObj, mObj);
     //  Find the relevant traces to store

--- a/src/josim.cpp
+++ b/src/josim.cpp
@@ -50,9 +50,9 @@ int main(int argc, const char** argv) {
     // Create the matrix in csr format
     mObj.create_matrix(iObj);
     // Do sanity check
-    if (cli_options.sanity_check) {
+    if (cli_options.sanityCheck) {
       mObj.update_maindesign_node_counts(iObj.netlist);
-      iObj.netlist.sanity_check_maindesign();
+      iObj.netlist.sanity_check();
     }
     // Do verbosity
     Verbose::handle_verbosity(iObj.argVerb, iObj, mObj);


### PR DESCRIPTION
Hi all, JoSIM is a wonderful tool and I love using it.
When performing analog simulations of large-scale superconductor flux-quantum circuits, it is more productive to construct high-level circuits using logic cells defined as subcircuits. However, in such high-level circuits, the splitting and merging of flux-quanta must be explicitly performed using the corresponding cells. Therefore, every node of the cells in the circuit must be connected to only one distinct node. If a circuit that does not meet this constraint is inadvertently passed through the simulation, identifying the cause from the simulation results becomes a painful debugging process.
To address this issue, this PR provides a new CLI option to explicitly perform a sanity check on the input circuit, thereby improving the productivity and usability of analog simulations of superconductor circuits.