### PR TITLE
Fix crash because of invalid optional access in CLI parser

### DIFF
--- a/src/CliOptions.cpp
+++ b/src/CliOptions.cpp
@@ -88,6 +88,7 @@ vector_pair_t<char_o, string_o> CliOptions::argument_pairs(
 CliOptions CliOptions::parse(int64_t argc, const char** argv) {
   // Variable where all the CLI options will be stored
   CliOptions out;
+  bool explicit_stdin_input = false;// Only used to suppress warning
   // Parse and generate argument pairs from tokens
   vector_pair_t<char_o, string_o> ap =
       out.argument_pairs(out.argv_to_tokens(argc, argv));
@@ -121,6 +122,7 @@ CliOptions CliOptions::parse(int64_t argc, const char** argv) {
           // Set input to standard input
         case 'i':
           out.cir_file_name = std::nullopt;
+          explicit_stdin_input = true;
           break;
           // Enable minimal reporting
         case 'm':
@@ -181,8 +183,9 @@ CliOptions CliOptions::parse(int64_t argc, const char** argv) {
   }
   // Do a few sanity checks
   // If the input was not specified
-  if (!out.cir_file_name) {
+  if (!out.cir_file_name && !(out.minimal && explicit_stdin_input)) {
     // Complain and assume standard input
+    // Suppress warning if -i AND -m options were given
     Errors::cli_errors(CLIErrors::NO_INPUT);
   }
   // If an output file and an input file name were specified

--- a/src/CliOptions.cpp
+++ b/src/CliOptions.cpp
@@ -185,9 +185,9 @@ CliOptions CliOptions::parse(int64_t argc, const char** argv) {
     // Complain and assume standard input
     Errors::cli_errors(CLIErrors::NO_INPUT);
   }
-  // If an output file name was specified
-  if (out.output_file) {
-    // But this matches the input file name
+  // If an output file and an input file name were specified
+  if (out.output_file && out.cir_file_name) {
+    // But they match each other
     if (out.output_file.value().name() == out.cir_file_name.value()) {
       // Complain and exit since continuing will overwrite input file
       Errors::cli_errors(CLIErrors::INPUT_SAME_OUTPUT);


### PR DESCRIPTION
Commit 41c71ac (Bugfix): When an output file name is given, but stdin is used as input (i. e. `josim-cli -i -o out.csv`), the program crashed because of std::bad_optional_access when checking whether the file names are equal in CliOptions::parse. This crash is fixed by skipping the check if no input file name is given (in that case the check would be pointless anyway).

Commit 8a0193d (Minor Change): JoSIM warns if no input file name is given and therefore stdin is used. This is true even if this behavior is explicitly wanted by the -i switch. This commit disables the warning if -i AND -m are given, i. e. the user explicitly wishes to use stdin AND wants minimal logging.

This pull request is unrelated to PR#98.