### PR TITLE
Fix crashes on shorted componentes

### DIFF
--- a/docs/comp_stamps.md
+++ b/docs/comp_stamps.md
@@ -755,7 +755,7 @@ I_{out} = \beta I_{in}
 $$
 
 $$
-V_{1} - V_{2} = 0
+V_{3} - V_{4} = 0
 $$
 
 $$
@@ -764,11 +764,11 @@ $$
 
 $$
 \begin{bmatrix}
-	0 & 0 & 0 & 0 & \frac{1}{\beta} \\
-	0 & 0 & 0 & 0 & -\frac{1}{\beta} \\	
 	0 & 0 & 0 & 0 & 1 \\
 	0 & 0 & 0 & 0 & -1 \\
-	1 & -1 & 0 & 0 & 0
+	0 & 0 & 0 & 0 & \frac{1}{\beta} \\
+	0 & 0 & 0 & 0 & -\frac{1}{\beta} \\
+	0 & 0 & 1 & -1 & 0
 	\end{bmatrix}
 	\begin{bmatrix}
 	V_{1}\\
@@ -795,21 +795,21 @@ $$
 Current controlled voltage source allows the modulation of a voltage node through a remote current.
 
 $$
-V_{1} - V_{2} = 0
+V_{3} - V_{4} = 0
 $$
 
 $$
-V_{3} - V_{4} = \mu I_{in}
+V_{1} - V_{2} = \mu I_{in}
 $$
 
 $$
 \begin{bmatrix}
-0 & 0 & 0 & 0 & 1 & 0\\
-0 & 0 & 0 & 0 & -1 & 0\\
 0 & 0 & 0 & 0 & 0 & 1\\
 0 & 0 & 0 & 0 & 0 & -1\\
-0 & 0 & 1 & -1 & -\mu & 0\\
-1 & -1 & 0 & 0 & 0 & -\mu
+0 & 0 & 0 & 0 & 1 & 0\\
+0 & 0 & 0 & 0 & -1 & 0\\
+1 & -1 & 0 & 0 & -\mu & 0\\
+0 & 0 & 1 & -1 & 0 & 0
 \end{bmatrix}
 \begin{bmatrix}
 V_{1}\\
@@ -837,16 +837,16 @@ $$
 Voltage controlled current source allows the modulation of a current in a branch through a remote voltage.
 
 $$
-\alpha(V_{1} - V_{2}) = I_{out}
+\alpha(V_{3} - V_{4}) = I_{out}
 $$
 
 $$
 \begin{bmatrix}
-0 & 0 & 0 & 0 & 0\\
-0 & 0 & 0 & 0 & 0\\
 0 & 0 & 0 & 0 & 1\\
 0 & 0 & 0 & 0 & -1\\
-1 & -1 & 0 & 0 & -\frac{1}{\alpha}
+0 & 0 & 0 & 0 & 0\\
+0 & 0 & 0 & 0 & 0\\
+0 & 0 & 1 & -1 & -\frac{1}{\alpha}
 \end{bmatrix}
 \begin{bmatrix}
 V_{1}\\
@@ -873,16 +873,16 @@ $$
 Voltage controlled current source allows the modulation of a current in a branch through a remote voltage.
 
 $$
-A(V_{1} - V_{2}) = V_{3}-V_{4}
+A(V_{3} - V_{4}) = V_{1}-V_{2}
 $$
 
 $$
 \begin{bmatrix}
-0 & 0 & 0 & 0 & 0\\
-0 & 0 & 0 & 0 & 0\\
 0 & 0 & 0 & 0 & 1\\
 0 & 0 & 0 & 0 & -1\\
-G & -G & 1 & -1 & 0
+0 & 0 & 0 & 0 & 0\\
+0 & 0 & 0 & 0 & 0\\
+-1 & 1 & A & -A & 0
 \end{bmatrix}
 \begin{bmatrix}
 V_{1}\\

--- a/include/JoSIM/BasicComponent.hpp
+++ b/include/JoSIM/BasicComponent.hpp
@@ -59,10 +59,12 @@ class BasicComponent {
       case NodeConfig::POSNEG:
         indexInfo.posIndex_ = nm.at(t.at(0));
         indexInfo.negIndex_ = nm.at(t.at(1));
-        nc.at(nm.at(t.at(0)))
-            .emplace_back(std::make_pair(1, indexInfo.currentIndex_.value()));
-        nc.at(nm.at(t.at(1)))
-            .emplace_back(std::make_pair(-1, indexInfo.currentIndex_.value()));
+        if (indexInfo.posIndex_.value() != indexInfo.negIndex_.value()) {
+          nc.at(nm.at(t.at(0)))
+              .emplace_back(std::make_pair(1, indexInfo.currentIndex_.value()));
+          nc.at(nm.at(t.at(1)))
+              .emplace_back(std::make_pair(-1, indexInfo.currentIndex_.value()));
+        }
         break;
       case NodeConfig::GND:
         break;
@@ -82,11 +84,15 @@ class BasicComponent {
         matrixInfo.rowPointer_.emplace_back(2);
         break;
       case NodeConfig::POSNEG:
-        matrixInfo.nonZeros_.emplace_back(1);
-        matrixInfo.nonZeros_.emplace_back(-1);
-        matrixInfo.columnIndex_.emplace_back(indexInfo.posIndex_.value());
-        matrixInfo.columnIndex_.emplace_back(indexInfo.negIndex_.value());
-        matrixInfo.rowPointer_.emplace_back(3);
+        if (indexInfo.posIndex_.value() != indexInfo.negIndex_.value()) {
+          matrixInfo.nonZeros_.emplace_back(1);
+          matrixInfo.nonZeros_.emplace_back(-1);
+          matrixInfo.columnIndex_.emplace_back(indexInfo.posIndex_.value());
+          matrixInfo.columnIndex_.emplace_back(indexInfo.negIndex_.value());
+          matrixInfo.rowPointer_.emplace_back(3);
+        } else {
+          matrixInfo.rowPointer_.emplace_back(1);
+        }
         break;
       case NodeConfig::GND:
         matrixInfo.rowPointer_.emplace_back(1);

--- a/src/CCCS.cpp
+++ b/src/CCCS.cpp
@@ -67,10 +67,13 @@ void CCCS::set_node_indices(const tokens_t& t, const nodemap& nm,
     case NodeConfig::POSNEG:
       indexInfo.posIndex_ = nm.at(t.at(0));
       indexInfo.negIndex_ = nm.at(t.at(1));
-      nc.at(nm.at(t.at(0)))
-          .emplace_back(std::make_pair(1, indexInfo.currentIndex_.value()));
-      nc.at(nm.at(t.at(1)))
-          .emplace_back(std::make_pair(-1, indexInfo.currentIndex_.value()));
+      if (indexInfo.posIndex_.value() != indexInfo.negIndex_.value()) {
+        // If this condition is false, the matrix will be singular and the program will throw an error.
+        nc.at(nm.at(t.at(0)))
+            .emplace_back(std::make_pair(1, indexInfo.currentIndex_.value()));
+        nc.at(nm.at(t.at(1)))
+            .emplace_back(std::make_pair(-1, indexInfo.currentIndex_.value()));
+      }
       break;
     case NodeConfig::GND:
       break;
@@ -92,12 +95,16 @@ void CCCS::set_node_indices(const tokens_t& t, const nodemap& nm,
     case NodeConfig::POSNEG:
       posIndex2_ = nm.at(t.at(2));
       negIndex2_ = nm.at(t.at(3));
-      nc.at(nm.at(t.at(2)))
-          .emplace_back(std::make_pair((1 / netlistInfo.value_),
-                                       indexInfo.currentIndex_.value()));
-      nc.at(nm.at(t.at(3)))
-          .emplace_back(std::make_pair(-(1 / netlistInfo.value_),
-                                       indexInfo.currentIndex_.value()));
+      if (posIndex2_.value() != negIndex2_.value()) {
+        // If the controlled source is short-circuited, the whole component is
+        // equivalent to a 0-voltage source on the controlling nodes, which is legal.
+        nc.at(nm.at(t.at(2)))
+            .emplace_back(std::make_pair((1 / netlistInfo.value_),
+                                        indexInfo.currentIndex_.value()));
+        nc.at(nm.at(t.at(3)))
+            .emplace_back(std::make_pair(-(1 / netlistInfo.value_),
+                                        indexInfo.currentIndex_.value()));
+      }
       break;
     case NodeConfig::GND:
       break;
@@ -117,11 +124,13 @@ void CCCS::set_matrix_info() {
       matrixInfo.rowPointer_.emplace_back(1);
       break;
     case NodeConfig::POSNEG:
-      matrixInfo.nonZeros_.emplace_back(1);
-      matrixInfo.nonZeros_.emplace_back(-1);
-      matrixInfo.columnIndex_.emplace_back(posIndex2_.value());
-      matrixInfo.columnIndex_.emplace_back(negIndex2_.value());
-      matrixInfo.rowPointer_.emplace_back(2);
+      if (posIndex2_.value() != negIndex2_.value()) {
+        matrixInfo.nonZeros_.emplace_back(1);
+        matrixInfo.nonZeros_.emplace_back(-1);
+        matrixInfo.columnIndex_.emplace_back(posIndex2_.value());
+        matrixInfo.columnIndex_.emplace_back(negIndex2_.value());
+        matrixInfo.rowPointer_.emplace_back(2);
+      }
       break;
     case NodeConfig::GND:
       break;

--- a/src/JJ.cpp
+++ b/src/JJ.cpp
@@ -144,11 +144,15 @@ void JJ::set_matrix_info() {
       matrixInfo.rowPointer_.emplace_back(2);
       break;
     case NodeConfig::POSNEG:
-      matrixInfo.nonZeros_.emplace_back(1);
-      matrixInfo.nonZeros_.emplace_back(-1);
-      matrixInfo.columnIndex_.emplace_back(indexInfo.posIndex_.value());
-      matrixInfo.columnIndex_.emplace_back(indexInfo.negIndex_.value());
-      matrixInfo.rowPointer_.emplace_back(3);
+      if (indexInfo.posIndex_.value() != indexInfo.negIndex_.value()) {
+        matrixInfo.nonZeros_.emplace_back(1);
+        matrixInfo.nonZeros_.emplace_back(-1);
+        matrixInfo.columnIndex_.emplace_back(indexInfo.posIndex_.value());
+        matrixInfo.columnIndex_.emplace_back(indexInfo.negIndex_.value());
+        matrixInfo.rowPointer_.emplace_back(3);
+      } else {
+        matrixInfo.rowPointer_.emplace_back(1);
+      }
       break;
     case NodeConfig::GND:
       matrixInfo.rowPointer_.emplace_back(1);

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -216,7 +216,7 @@ void Simulation::handle_cs(Matrix &mObj, double &step, const int64_t &i) {
     } else if (j.indexInfo.nodeConfig_ == NodeConfig::GNDNEG) {
       b_.at(j.indexInfo.negIndex_.value()) +=
           (mObj.sourcegen.at(j.sourceIndex_).value(step));
-    } else {
+    } else if (j.indexInfo.nodeConfig_ == NodeConfig::POSNEG) {
       b_.at(j.indexInfo.posIndex_.value()) -=
           (mObj.sourcegen.at(j.sourceIndex_).value(step));
       b_.at(j.indexInfo.negIndex_.value()) +=
@@ -241,7 +241,7 @@ void Simulation::handle_resistors(Matrix &mObj, double &step) {
             temp.thermalNoise.value().value(step);
       }
       temp.pn1_ = (-x_.at(temp.indexInfo.negIndex_.value()));
-    } else {
+    } else if (nc == NodeConfig::POSNEG) {
       if (temp.thermalNoise) {
         b_.at(temp.indexInfo.posIndex_.value()) -=
             temp.thermalNoise.value().value(step);
@@ -250,6 +250,8 @@ void Simulation::handle_resistors(Matrix &mObj, double &step) {
       }
       temp.pn1_ = (x_.at(temp.indexInfo.posIndex_.value()) -
                    x_.at(temp.indexInfo.negIndex_.value()));
+    } else {
+      temp.pn1_ = 0.0;
     }
     if (atyp_ == AnalysisType::Phase) {
       // 4/3 φp1 - 1/3 φp2
@@ -294,9 +296,11 @@ void Simulation::handle_capacitors(Matrix &mObj) {
       temp.pn1_ = (x_.at(temp.indexInfo.posIndex_.value()));
     } else if (!temp.indexInfo.posIndex_ && temp.indexInfo.negIndex_) {
       temp.pn1_ = (-x_.at(temp.indexInfo.negIndex_.value()));
-    } else {
+    } else if (temp.indexInfo.posIndex_ && temp.indexInfo.negIndex_) {
       temp.pn1_ = (x_.at(temp.indexInfo.posIndex_.value()) -
                    x_.at(temp.indexInfo.negIndex_.value()));
+    } else {
+      temp.pn1_ = 0.0;
     }
     if (atyp_ == AnalysisType::Voltage) {
       // 4/3 Vp1 - 1/3 Vp2
@@ -334,7 +338,7 @@ void Simulation::handle_jj(Matrix &mObj, int64_t &i, double &step,
             temp.thermalNoise.value().value(step);
       }
       temp.pn1_ = (-x_.at(temp.indexInfo.negIndex_.value()));
-    } else {
+    } else if (temp.indexInfo.posIndex_ && temp.indexInfo.negIndex_) {
       if (temp.thermalNoise) {
         b_.at(temp.indexInfo.posIndex_.value()) -=
             temp.thermalNoise.value().value(step);
@@ -343,6 +347,8 @@ void Simulation::handle_jj(Matrix &mObj, int64_t &i, double &step,
       }
       temp.pn1_ = (x_.at(temp.indexInfo.posIndex_.value()) -
                    x_.at(temp.indexInfo.negIndex_.value()));
+    } else {
+      temp.pn1_ = 0.0;
     }
     if (i > 0) {
       if (atyp_ == AnalysisType::Voltage) {
@@ -456,9 +462,14 @@ void Simulation::handle_vs(Matrix &mObj, const int64_t &i, double &step,
         temp.pn1_ = (x_.at(temp.indexInfo.posIndex_.value()));
       } else if (nc == NodeConfig::GNDNEG) {
         temp.pn1_ = (-x_.at(temp.indexInfo.negIndex_.value()));
-      } else {
+      } else if (nc == NodeConfig::POSNEG) {
         temp.pn1_ = (x_.at(temp.indexInfo.posIndex_.value()) -
                      x_.at(temp.indexInfo.negIndex_.value()));
+      } else {
+        // This branch is only taken as a result of a GND-GND short-circuited voltage source.
+        // In this case, the matrix is singular and the program will throw an error.
+        // Without this branch, the program could crash due to std::bad_optional_access.
+        temp.pn1_ = 0.0;
       }
       // (2e/hbar)(2h/3)Vn + (4/3)φn-1 - (1/3)φn-2
       b_.at(temp.indexInfo.currentIndex_.value()) =
@@ -512,9 +523,11 @@ void Simulation::handle_ccvs(Matrix &mObj) {
         temp.pn1_ = (x_.at(temp.indexInfo.posIndex_.value()));
       } else if (!temp.indexInfo.posIndex_ && temp.indexInfo.negIndex_) {
         temp.pn1_ = (-x_.at(temp.indexInfo.negIndex_.value()));
-      } else {
+      } else if (temp.indexInfo.posIndex_ && temp.indexInfo.negIndex_) {
         temp.pn1_ = (x_.at(temp.indexInfo.posIndex_.value()) -
                      x_.at(temp.indexInfo.negIndex_.value()));
+      } else {
+        temp.pn1_ = 0.0;
       }
       b_.at(temp.indexInfo.currentIndex_.value()) =
           (4.0 / 3.0) * temp.pn1_ - (1.0 / 3.0) * temp.pn2_;
@@ -533,9 +546,11 @@ void Simulation::handle_vccs(Matrix &mObj) {
         temp.pn1_ = (x_.at(temp.posIndex2_.value()));
       } else if (!temp.posIndex2_ && temp.negIndex2_) {
         temp.pn1_ = (-x_.at(temp.negIndex2_.value()));
-      } else {
+      } else if (temp.posIndex2_ && temp.negIndex2_) {
         temp.pn1_ =
             (x_.at(temp.posIndex2_.value()) - x_.at(temp.negIndex2_.value()));
+      } else {
+        temp.pn1_ = 0.0;
       }
       b_.at(temp.indexInfo.currentIndex_.value()) =
           (4.0 / 3.0) * temp.pn1_ - (1.0 / 3.0) * temp.pn2_;
@@ -572,6 +587,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
         } else if (nc == NodeConfig::POSNEG) {
           temp.nk_1_ = results.xVector.at(posInd.value()).value().at(i - k) -
                        results.xVector.at(negInd.value()).value().at(i - k);
+        } else {
+          temp.nk_1_ = 0.0;
         }
         // φ2n-k
         if (nc2 == NodeConfig::POSGND) {
@@ -581,6 +598,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
         } else if (nc2 == NodeConfig::POSNEG) {
           temp.nk_2_ = results.xVector.at(posInd2.value()).value().at(i - k) -
                        results.xVector.at(negInd2.value()).value().at(i - k);
+        } else {
+          temp.nk_2_ = 0.0;
         }
         // I1n-k
         double &I1nk = results.xVector.at(curInd).value().at(i - k);
@@ -602,6 +621,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
           temp.n1_1_ = (-x_.at(negInd.value()));
         } else if (nc == NodeConfig::POSNEG) {
           temp.n1_1_ = (x_.at(posInd.value()) - x_.at(negInd.value()));
+        } else {
+          temp.n1_1_ = 0.0;
         }
         // φ2n-1
         if (nc2 == NodeConfig::POSGND) {
@@ -610,6 +631,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
           temp.n1_2_ = (-x_.at(negInd2.value()));
         } else if (nc2 == NodeConfig::POSNEG) {
           temp.n1_2_ = (x_.at(posInd2.value()) - x_.at(negInd2.value()));
+        } else {
+          temp.n1_2_ = 0.0;
         }
       }
       if (i >= k) {
@@ -621,6 +644,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
         } else if (nc == NodeConfig::POSNEG) {
           temp.nk_1_ = results.xVector.at(posInd.value()).value().at(i - k) -
                        results.xVector.at(negInd.value()).value().at(i - k);
+        } else {
+          temp.nk_1_ = 0.0;
         }
         // φ2n-k
         if (nc2 == NodeConfig::POSGND) {
@@ -630,6 +655,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
         } else if (nc2 == NodeConfig::POSNEG) {
           temp.nk_2_ = results.xVector.at(posInd2.value()).value().at(i - k) -
                        results.xVector.at(negInd2.value()).value().at(i - k);
+        } else {
+          temp.nk_2_ = 0.0;
         }
         // I1n-k
         double &I1nk = results.xVector.at(curInd).value().at(i - k);
@@ -658,6 +685,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
             temp.nk1_1_ =
                 results.xVector.at(posInd.value()).value().at(i - k - 1) -
                 results.xVector.at(negInd.value()).value().at(i - k - 1);
+          } else {
+            temp.nk1_1_ = 0.0;
           }
           // φ2n-k-1
           if (nc2 == NodeConfig::POSGND) {
@@ -670,6 +699,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
             temp.nk1_2_ =
                 results.xVector.at(posInd2.value()).value().at(i - k - 1) -
                 results.xVector.at(negInd2.value()).value().at(i - k - 1);
+          } else {
+            temp.nk1_2_ = 0.0;
           }
           // I1 = Z(2e/hbar)(2h/3)I2n-k + (4/3)φ1n-1 - (1/3)φ1n-2 +
           //      φ2n-k - (4/3)φ2n-k-1
@@ -695,6 +726,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
             temp.nk1_1_ =
                 results.xVector.at(posInd.value()).value().at(i - k - 1) -
                 results.xVector.at(negInd.value()).value().at(i - k - 1);
+          } else {
+            temp.nk1_1_ = 0.0;
           }
           // φ2n-k-1
           if (nc2 == NodeConfig::POSGND) {
@@ -707,6 +740,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
             temp.nk1_2_ =
                 results.xVector.at(posInd2.value()).value().at(i - k - 1) -
                 results.xVector.at(negInd2.value()).value().at(i - k - 1);
+          } else {
+            temp.nk1_2_ = 0.0;
           }
           // φ1n-k-2
           if (nc == NodeConfig::POSGND) {
@@ -719,6 +754,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
             temp.nk2_1_ =
                 results.xVector.at(posInd.value()).value().at(i - k - 2) -
                 results.xVector.at(negInd.value()).value().at(i - k - 2);
+          } else {
+            temp.nk2_1_ = 0.0;
           }
           // φ2n-k-2
           if (nc2 == NodeConfig::POSGND) {
@@ -731,6 +768,8 @@ void Simulation::handle_tx(Matrix &mObj, const int64_t &i, double &step,
             temp.nk2_2_ =
                 results.xVector.at(posInd2.value()).value().at(i - k - 2) -
                 results.xVector.at(negInd2.value()).value().at(i - k - 2);
+          } else {
+            temp.nk2_2_ = 0.0;
           }
           // I1 = Z(2e/hbar)(2h/3)I2n-k + (4/3)φ1n-1 - (1/3)φ1n-2 +
           //      φ2n-k - (4/3)φ2n-k-1 + (1/3)φ2n-k-2

--- a/src/TransmissionLine.cpp
+++ b/src/TransmissionLine.cpp
@@ -146,8 +146,10 @@ void TransmissionLine::set_secondary_node_indices(const tokens_t& t,
     case NodeConfig::POSNEG:
       posIndex2_ = nm.at(t.at(0));
       negIndex2_ = nm.at(t.at(1));
-      nc.at(nm.at(t.at(0))).emplace_back(std::make_pair(1, currentIndex2_));
-      nc.at(nm.at(t.at(1))).emplace_back(std::make_pair(-1, currentIndex2_));
+      if (posIndex2_.value() != negIndex2_.value()) {
+        nc.at(nm.at(t.at(0))).emplace_back(std::make_pair(1, currentIndex2_));
+        nc.at(nm.at(t.at(1))).emplace_back(std::make_pair(-1, currentIndex2_));
+      }
       break;
     case NodeConfig::GND:
       break;
@@ -168,11 +170,15 @@ void TransmissionLine::set_secondary_matrix_info() {
       matrixInfo.rowPointer_.emplace_back(2);
       break;
     case NodeConfig::POSNEG:
-      matrixInfo.nonZeros_.emplace_back(1);
-      matrixInfo.nonZeros_.emplace_back(-1);
-      matrixInfo.columnIndex_.emplace_back(posIndex2_.value());
-      matrixInfo.columnIndex_.emplace_back(negIndex2_.value());
-      matrixInfo.rowPointer_.emplace_back(3);
+      if (posIndex2_.value() != negIndex2_.value()) {
+        matrixInfo.nonZeros_.emplace_back(1);
+        matrixInfo.nonZeros_.emplace_back(-1);
+        matrixInfo.columnIndex_.emplace_back(posIndex2_.value());
+        matrixInfo.columnIndex_.emplace_back(negIndex2_.value());
+        matrixInfo.rowPointer_.emplace_back(3);
+      } else {
+        matrixInfo.rowPointer_.emplace_back(1);
+      }
       break;
     case NodeConfig::GND:
       matrixInfo.rowPointer_.emplace_back(1);

--- a/src/VCCS.cpp
+++ b/src/VCCS.cpp
@@ -83,10 +83,12 @@ void VCCS::set_node_indices(const tokens_t& t, const nodemap& nm,
     case NodeConfig::POSNEG:
       indexInfo.posIndex_ = nm.at(t.at(0));
       indexInfo.negIndex_ = nm.at(t.at(1));
-      nc.at(nm.at(t.at(0)))
-          .emplace_back(std::make_pair(1, indexInfo.currentIndex_.value()));
-      nc.at(nm.at(t.at(1)))
-          .emplace_back(std::make_pair(-1, indexInfo.currentIndex_.value()));
+      if (indexInfo.posIndex_.value() != indexInfo.negIndex_.value()) {
+        nc.at(nm.at(t.at(0)))
+            .emplace_back(std::make_pair(1, indexInfo.currentIndex_.value()));
+        nc.at(nm.at(t.at(1)))
+            .emplace_back(std::make_pair(-1, indexInfo.currentIndex_.value()));
+      }
       break;
     case NodeConfig::GND:
       break;
@@ -121,11 +123,15 @@ void VCCS::set_matrix_info() {
       matrixInfo.rowPointer_.emplace_back(2);
       break;
     case NodeConfig::POSNEG:
-      matrixInfo.nonZeros_.emplace_back(1);
-      matrixInfo.nonZeros_.emplace_back(-1);
-      matrixInfo.columnIndex_.emplace_back(posIndex2_.value());
-      matrixInfo.columnIndex_.emplace_back(negIndex2_.value());
-      matrixInfo.rowPointer_.emplace_back(3);
+      if (posIndex2_.value() != negIndex2_.value()) {
+        matrixInfo.nonZeros_.emplace_back(1);
+        matrixInfo.nonZeros_.emplace_back(-1);
+        matrixInfo.columnIndex_.emplace_back(posIndex2_.value());
+        matrixInfo.columnIndex_.emplace_back(negIndex2_.value());
+        matrixInfo.rowPointer_.emplace_back(3);
+      } else {
+        matrixInfo.rowPointer_.emplace_back(1);
+      }
       break;
     case NodeConfig::GND:
       matrixInfo.rowPointer_.emplace_back(1);


### PR DESCRIPTION
This PR fixes several related bugs where the program would crash when both pins of a component are connected to the same node. While appearing pointless, this is useful when the user wants to short-circuit or ground unused pins of subcircuits (e.g. exported S-parameters from CST Studio). In particular:

- When both pins are connected to GND, `handle_*()` (called by `setup_b()`) threw a `std::bad_optional_access` exception, because the NodeConfig::GND case was not handled and the program defaulted to NodeConfig::POSNEG, trying to access nonexisting voltage nodes.
- When both pins are connected to the same non-GND node, `BasicComponent::set_node_indices()` and `BasicComponent::set_matrix_info()` (as well as equivalent functions of derived classes) tried to create a +1 and -1 entry pair in matrixInfo on the same spot in the matrix, leading to an invalid CSR representation, which was reported to be singular, when in fact the correct matrix (with 1 - 1 = 0 as an entry) would be perfectly fine for some components like resistors.
- For VCVS, the program could segfault in `VCVS::set_matrix_info()` on the access to `matrixInfo.rowPointer_.back()` in case `indexInfo.nodeConfig_ == NodeConfig::GND`.

For some components, being short-circuited is fine logically (e.g. resistor, capacitor, inductor, current source, control nodes of VCVS), while for others it results in a singular equation system (voltage source and control nodes of CCCS / CCVC). Previously, the program would crash in many cases, whereas now, it handles the valid cases as expected and reports a singular matrix on the invalid ones.

Furthermore, the direction of output current (but not output voltage) is inverted for CCVS / VCVS in `set_node_indices()` to reflect the documentation and the convention already used by the uncontrolled voltage source (P=V*I is positive for consumed power). This shouldn't break existing circuits, but it does flip the sign of printed device currents of VCVSes.

The documentation contained errors for controlled sources (especially that the controlling and controlled nodes were flipped), which are fixed.

The included tests all still pass. Many variations of short-circuited components were tested manually and now work as expected.